### PR TITLE
Set repo up to work while dev'ing in Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,194 @@
+## AUTOCRLF all text files
+## This will handle all files NOT overridden below
+*  text=auto
+
+## TERRAFORM
+/terraform/*  text eol=lf
+*.ps1         text eol=crlf
+
+## C-SHARP C#
+*.cs      text diff=csharp
+*.xaml    text
+*.csproj  text
+*.sln     text
+*.tt      text
+*.ps1     text
+*.cmd     text
+*.msbuild text
+*.md      text
+
+## SOURCE CODE
+*.bat      text eol=crlf
+*.coffee   text
+*.css      text diff=css
+*.htm      text
+*.html     text diff=html
+*.inc      text
+*.ini      text
+*.js       text eol=lf
+*.json     text eol=lf
+*.jsx      text eol=lf
+*.less     text
+*.od       text
+*.onlydata text
+*.php      text
+*.pl       text
+*.py       text diff=python
+*.rb       text diff=ruby
+*.sass     text diff=css
+*.scm      text
+*.scss     text diff=css
+*.sh       text eol=lf
+*.sql      text
+*.styl     text
+*.tag      text
+*.ts       text
+*.tsx      text
+*.xml      text
+*.xhtml    text
+
+## DOCKER
+*.dockerignore    text
+Dockerfile    text
+
+## DOCUMENTATION
+*.markdown   text
+*.md         text
+*.mdwn       text
+*.mdown      text
+*.mkd        text
+*.mkdn       text
+*.mdtxt      text
+*.mdtext     text
+*.txt        text
+AUTHORS      text
+CHANGELOG    text
+CHANGES      text
+CONTRIBUTING text
+COPYING      text
+copyright    text
+*COPYRIGHT*  text
+INSTALL      text
+license      text
+LICENSE      text
+NEWS         text
+readme       text
+*README*     text
+TODO         text
+
+## TEMPLATES
+*.dot        text
+*.ejs        text
+*.haml       text
+*.handlebars text
+*.hbs        text
+*.hbt        text
+*.jade       text
+*.latte      text
+*.mustache   text
+*.njk        text
+*.phtml      text
+*.tmpl       text
+*.tpl        text
+*.twig       text
+
+## LINTERS
+.csslintrc    text
+.eslintrc     text
+.htmlhintrc   text
+.jscsrc       text
+.jshintrc     text
+.jshintignore text
+.stylelintrc  text
+
+## CONFIGS
+*.bowerrc      text
+*.cnf          text
+*.conf         text
+*.config       text
+.browserslistrc    text
+.editorconfig  text
+.gitattributes text
+.gitconfig     text
+.gitignore     text
+.htaccess      text
+*.npmignore    text
+*.yaml         text
+*.yml          text
+browserslist   text
+Makefile       text
+makefile       text
+
+## HEROKU
+Procfile    text
+.slugignore text
+
+## GRAPHICS
+*.ai   binary
+*.bmp  binary
+*.eps  binary
+*.gif  binary
+*.ico  binary
+*.jng  binary
+*.jp2  binary
+*.jpg  binary
+*.jpeg binary
+*.jpx  binary
+*.jxr  binary
+*.pdf  binary
+*.png  binary
+*.psb  binary
+*.psd  binary
+*.svg  text
+*.svgz binary
+*.tif  binary
+*.tiff binary
+*.wbmp binary
+*.webp binary
+
+## AUDIO
+*.kar  binary
+*.m4a  binary
+*.mid  binary
+*.midi binary
+*.mp3  binary
+*.ogg  binary
+*.ra   binary
+
+## VIDEO
+*.3gpp binary
+*.3gp  binary
+*.as   binary
+*.asf  binary
+*.asx  binary
+*.fla  binary
+*.flv  binary
+*.m4v  binary
+*.mng  binary
+*.mov  binary
+*.mp4  binary
+*.mpeg binary
+*.mpg  binary
+*.ogv  binary
+*.swc  binary
+*.swf  binary
+*.webm binary
+
+## ARCHIVES
+*.7z  binary
+*.gz  binary
+*.jar binary
+*.rar binary
+*.tar binary
+*.zip binary
+
+## FONTS
+*.ttf   binary
+*.eot   binary
+*.otf   binary
+*.woff  binary
+*.woff2 binary
+
+## EXECUTABLES
+*.exe binary
+*.pyc binary

--- a/package-lock.json
+++ b/package-lock.json
@@ -3159,6 +3159,29 @@
         "sha.js": "^2.4.8"
       }
     },
+    "cross-env": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
+      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
+      "requires": {
+        "cross-spawn": "^6.0.5",
+        "is-windows": "^1.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "body-parser": "^1.17.2",
     "cors": "^2.8.4",
+    "cross-env": "^5.2.0",
     "dotenv": "^4.0.0",
     "electron-debug": "^1.5.0",
     "electron-is-dev": "^0.3.0",
@@ -94,9 +95,9 @@
     "whatwg-fetch": "2.0.3"
   },
   "scripts": {
-    "start": "BROWSER=none node scripts/start.js",
+    "start": "cross-env BROWSER=none node scripts/start.js",
     "stub:server": "nodemon stubServer",
-    "stub:start": "BROWSER=none REACT_APP_GITHUB_API_URL=http://localhost:3334/graphql REACT_APP_OAUTH_GATEKEEPER_URL=http://localhost:3334/authenticate REACT_APP_GITHUB_AUTH_URL=http://localhost:3334/oauth/authorize node scripts/start.js",
+    "stub:start": "cross-env BROWSER=none REACT_APP_GITHUB_API_URL=http://localhost:3334/graphql REACT_APP_OAUTH_GATEKEEPER_URL=http://localhost:3334/authenticate REACT_APP_GITHUB_AUTH_URL=http://localhost:3334/oauth/authorize node scripts/start.js",
     "stub": "run-p stub:*",
     "serve": "npm run build && node server",
     "react-build": "node scripts/build.js",
@@ -106,8 +107,8 @@
     "style-fix": "eslint --fix '**/*.js'",
     "validate": "npm run test && npm run style",
     "precommit": "npm run style && npm run test:no-watcher",
-    "electron": "NODE_ENV=production electron .",
-    "electron-dev": "ELECTRON_START_URL=http://localhost:3333/app electron .",
+    "electron": "cross-env NODE_ENV=production electron .",
+    "electron-dev": "cross-env ELECTRON_START_URL=http://localhost:3333/app electron .",
     "pack": "npm run react-build && build --dir",
     "dist": "npm run react-build && build",
     "ship": "npm run react-build && build --publish always"

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "serve": "npm run build && node server",
     "react-build": "node scripts/build.js",
     "test": "node scripts/test.js  --config .jestrc.json --env=jsdom",
-    "test:no-watcher": "CI=true npm run test",
+    "test:no-watcher": "cross-env CI=true npm run test",
     "style": "eslint '**/*.js'",
     "style-fix": "eslint --fix '**/*.js'",
     "validate": "npm run test && npm run style",


### PR DESCRIPTION
Closes #78 

This PR allows you to dev with this repo on Windows by:
1. Adding the cross-env package to set env vars in package.json
2. Adding a .gitattributes file so files are checked in uniformly
