### PR TITLE
Adding support for a different domain than GitHub.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ React and Apollo dev tools will be available inside the Chrome dev tools.
 
 Pullp uses an external auth server to complete Github sign in and receive a token for the Github API. You may want to host a local version of this server. Clone it from https://github.com/rkclark/pullp-oauth-gatekeeper, run it on the port of your choosing and then add the server URL to `REACT_APP_OAUTH_GATEKEEPER_URL` in the `/env/.env.development` file inside of Pullp.
 
+If you are connecting to a different GitHub domain than `github.com`, you can set `REACT_APP_GITHUB_DOMAIN` to that domain such as `github.mycompany.com`
+
 Your oauth server will need set of Github oAuth app credentials. To make these:
 
 * In Github, go to your settings

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pullp",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": false,
   "main": "public/electron-starter.js",
   "license": "MIT",

--- a/public/electron-starter.js
+++ b/public/electron-starter.js
@@ -58,7 +58,7 @@ function createMainWindow() {
   });
 
   const handleRedirect = (e, navUrl) => {
-    if (navUrl.includes('github.com')) {
+    if (navUrl.includes(process.env.REACT_APP_GITHUB_DOMAIN || 'github.com')) {
       e.preventDefault();
       shell.openExternal(navUrl);
     }


### PR DESCRIPTION
Solving #76 

Adds a new env var REACT_APP_GITHUB_DOMAIN to allow for configuration of the Electron app to be able to redirect properly to a different GitHub domain than `github.com`